### PR TITLE
Point devvit dependency to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@devvit/public-api": "0.11.17-next-2025-06-12-824bd74c5.0",
     "@devvit/server": "0.11.17-next-2025-06-12-824bd74c5.0",
     "@devvit/redis": "0.11.17-next-2025-06-12-824bd74c5.0",
-    "devvit": "0.11.17-next-2025-06-12-824bd74c5.0",
+    "devvit": "latest",
     "express": "5.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Avoids CLI upgrade errors. SDK packages remain pinned.