### PR TITLE
Run init in the beginning of npm run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:server": "cd src/server && vite build",
     "build": "npm run build:client && npm run build:server",
     "deploy": "npm run build && devvit upload",
-    "dev": "npx devvit@next init && concurrently -k -p \"[{name}]\" -n \"CLIENT,SERVER,DEVVIT\" -c \"blue,green,magenta\" \"npm run dev:client\" \"npm run dev:server\" \"npm run dev:devvit\"",
+    "dev": "devvit init && concurrently -k -p \"[{name}]\" -n \"CLIENT,SERVER,DEVVIT\" -c \"blue,green,magenta\" \"npm run dev:client\" \"npm run dev:server\" \"npm run dev:devvit\"",
     "dev:client": "cd src/client && vite build --watch",
     "dev:devvit": "dotenv -e .env -- devvit playtest",
     "dev:server": "cd src/server && vite build --watch",


### PR DESCRIPTION
## 💸 TL;DR
Add `devvit init` as step in `npm run dev`. `init` is a no-op if the app is already initialized. This will make npm run dev work in Bolt from the get go.
